### PR TITLE
Corrected github link

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -44,7 +44,7 @@ If you find any errors in the conversion, file an issue in the [issue tracker].
 
 *—Alex Limi* · https://limi.net
 
-[issue tracker]:https://github.com/amigavision/DoubleTopaz/issues
+[issue tracker]:https://github.com/amigavision/TopazDouble/issues
 [Bob Burns]:https://youtu.be/p_A_ZrDaF9w
 [Peter J Cherna]:https://twitter.com/PChernaScala
 [Some Amiga History]:https://www.gregdonner.org/workbench/wb_14_20_explanation.html


### PR DESCRIPTION
The link to your project on Github was wrong. (DoubleTopaz instead of TopazDouble)
The same is true for the file Aminet readme file "TopazDouble.readme" which is not on Github.